### PR TITLE
Adding AntiNex to the List - Train AI (Keras + Tensorflow) to defend apps with Django REST Framework + Celery + Swagger + JWT - Anti-Nex REST API - Deploys to OpenShift Container Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[Universal adversarial perturbations](https://github.com/LTS4/universal)|
 |![][code]|[Malware Env for OpenAI Gym](https://github.com/endgameinc/gym-malware)|
 |![][code]|[Exploring the Space of Adversarial Images](https://github.com/tabacof/adversarial)|
+|![][code]|[AntiNex - Highly Accurate Deep Neural Networks to defend Software Systems from Network Exploits (works with docker-compose, Kubernetes and Openshift)](https://github.com/jay-johnson/train-ai-with-django-swagger-jwt)|
 
 ## [▲](#keywords) Links
 |Type|Title|


### PR DESCRIPTION
Hello, thanks for putting this list together.

I was wondering if my side project would make this list:

## Django REST Framework API (main repository)
- https://github.com/jay-johnson/train-ai-with-django-swagger-jwt

## Main docs site:
- http://antinex.readthedocs.io/

## Jupyter notebooks:
- https://github.com/jay-johnson/antinex-core/blob/master/docker/notebooks/AntiNex-Using-Pre-Trained-Deep-Neural-Networks-For-Defense.ipynb
- https://github.com/jay-johnson/antinex-core/blob/master/docker/notebooks/Slides-AntiNex-Protecting-Django.ipynb

## Datasets:a
- https://github.com/jay-johnson/antinex-datasets
- https://github.com/jay-johnson/network-pipeline-datasets