### PR TITLE
Add APort - Agent identity verification and policy enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|
 |![][code]|[SkillFortify - Formal analysis and supply chain security for agentic AI skills. Sound static analysis, SAT-based dependency resolution, trust scoring, CycloneDX ASBOM. 5 theorems, F1=96.95%, 0% FP rate](https://github.com/varun369/skillfortify)|
+|![][code]|[APort - Agent identity verification and policy enforcement for AI agents. Open-source with Python/Node.js SDKs and middleware for Express/FastAPI](https://github.com/aporthq)|
 
 ## [▲](#keywords) Links
 |Type|Title|


### PR DESCRIPTION
Adding [APort](https://github.com/aporthq) - an open-source framework for agent identity verification and policy enforcement for AI agents.

- Website: https://aport.io
- GitHub: https://github.com/aporthq
- Features: OAuth 2.0, JWT, mTLS, policy engine, Python & Node.js SDKs