### PR TITLE
Add ClawSec and ClawSearch - AI agent skill security

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[Exploring the Space of Adversarial Images](https://github.com/tabacof/adversarial)|
 |![][code]|[StringSifter - A machine learning tool that ranks strings based on their relevance for malware analysis](https://github.com/fireeye/stringsifter)|
 |![][code]|[CAI - Cybersecurity AI framework for autonomous security testing](https://github.com/aliasrobotics/CAI)|
+|![][code]|[ClawSec - Security audit platform for AI agent skills with five-tier detection, sandbox execution via Firecracker microVM, and continuous rule evolution](https://github.com/prompt-security/clawsec)|
+|![][code]|[ClawSearch - AI agent skill discovery platform with trust scoring, pre-install security checks, and vulnerability assessment](https://clawsearch.cc)|
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|
 |![][code]|[SkillFortify - Formal analysis and supply chain security for agentic AI skills. Sound static analysis, SAT-based dependency resolution, trust scoring, CycloneDX ASBOM. 5 theorems, F1=96.95%, 0% FP rate](https://github.com/varun369/skillfortify)|


### PR DESCRIPTION
## Summary

- Add [ClawSec](https://clawsec.cc) — security audit platform for AI agent skills with five-tier detection (core rules → dynamic rules → LLM analysis → Firecracker sandbox → LLM review), continuous rule evolution, and automated vulnerability reports.
- Add [ClawSearch](https://clawsearch.cc) — AI agent skill discovery platform with trust scoring, pre-install security checks, and vulnerability assessment across 33k+ skills.

Both entries are added to the **Code** section in alphabetical order, matching the existing table format.