### PR TITLE
Add operant-mcp: open-source MCP server with 51 security testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|
 |![][code]|[SkillFortify - Formal analysis and supply chain security for agentic AI skills. Sound static analysis, SAT-based dependency resolution, trust scoring, CycloneDX ASBOM. 5 theorems, F1=96.95%, 0% FP rate](https://github.com/varun369/skillfortify)|
+|![][code]|[operant-mcp - Open-source MCP server with 51 security testing tools for pentesting, vulnerability scanning, and security auditing. Covers SQLi, XSS, SSRF, IDOR, auth bypass, CORS, path traversal, command injection, NoSQL injection, PCAP analysis, and cloud security](https://github.com/operantlabs/operant-mcp)|
 
 ## [▲](#keywords) Links
 |Type|Title|


### PR DESCRIPTION
## Description

Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the Code section.

operant-mcp is an open-source MCP server with 51 security testing tools for pentesting, vulnerability scanning, and security auditing. It provides tools for SQLi, XSS, SSRF, IDOR, auth bypass, CORS, path traversal, command injection, NoSQL injection, PCAP analysis, and cloud security — usable directly by AI agents through the Model Context Protocol.

- License: MIT
- GitHub: https://github.com/operantlabs/operant-mcp