### PR TITLE
Add APort to AI security code resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[Malware Env for OpenAI Gym](https://github.com/endgameinc/gym-malware)|
 |![][code]|[Exploring the Space of Adversarial Images](https://github.com/tabacof/adversarial)|
 |![][code]|[StringSifter - A machine learning tool that ranks strings based on their relevance for malware analysis](https://github.com/fireeye/stringsifter)|
+|![][code]|[APort - Accountability infrastructure for AI agents with deterministic policy enforcement, agent identity, deliverable quality gates, and signed proofs](https://aport.io/)|
 |![][code]|[CAI - Cybersecurity AI framework for autonomous security testing](https://github.com/aliasrobotics/CAI)|
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|


### PR DESCRIPTION
Adds APort to the Code section as an AI-agent accountability and policy-enforcement resource.\n\nAPort fits this list because it focuses on deterministic pre-action policy enforcement, agent identity, deliverable quality gates, and signed proofs for AI agents.