### PR TITLE
Add APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[CAI - Cybersecurity AI framework for autonomous security testing](https://github.com/aliasrobotics/CAI)|
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|
+|![][code]|[APort Agent Guardrails - Pre-action authorization guardrails for AI agents that enforce policy before tool calls and produce auditable decisions](https://github.com/aporthq/aport-agent-guardrails)|
 |![][code]|[SkillFortify - Formal analysis and supply chain security for agentic AI skills. Sound static analysis, SAT-based dependency resolution, trust scoring, CycloneDX ASBOM. 5 theorems, F1=96.95%, 0% FP rate](https://github.com/varun369/skillfortify)|
 
 ## [▲](#keywords) Links


### PR DESCRIPTION
## Summary
- Add APort Agent Guardrails to the Code section as an AI-agent security tool.
- Keep the entry concise and aligned with the existing table format.

## Validation
- git diff --check
- Verified https://github.com/aporthq/aport-agent-guardrails returns HTTP 200