### PR TITLE
Add APort agent security tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|
 |![][code]|[SkillFortify - Formal analysis and supply chain security for agentic AI skills. Sound static analysis, SAT-based dependency resolution, trust scoring, CycloneDX ASBOM. 5 theorems, F1=96.95%, 0% FP rate](https://github.com/varun369/skillfortify)|
+|![][code]|[APort - Agent identity verification and policy enforcement for LLM tool calls, adding pre-action authorization guardrails before agents execute sensitive actions](https://aport.io)|
 
 ## [▲](#keywords) Links
 |Type|Title|


### PR DESCRIPTION
## Problem
APort is missing from this AI security resource list, even though it fits the agent runtime / guardrail category as a tool for agent identity and policy enforcement before sensitive tool calls execute.

## Summary
- Added APort with a one-sentence description.
- Placed it in the existing security/guardrail/runtime tooling section.

## Verification
- Ran git diff --check.
- Verified https://aport.io returns HTTP 200.

## Bounty
Related bounty issue: https://github.com/aporthq/aport-integrations/issues/19

Payment details if this PR qualifies for the bounty:
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y