### PR TITLE
Add SkilLock to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|
 |![][code]|[SkillFortify - Formal analysis and supply chain security for agentic AI skills. Sound static analysis, SAT-based dependency resolution, trust scoring, CycloneDX ASBOM. 5 theorems, F1=96.95%, 0% FP rate](https://github.com/varun369/skillfortify)|
+|![][code]|[SkilLock - Apache 2.0 lockfile + GitHub Action that pins the parsed behavior surface (shell commands, network URLs, file reads) of Claude Code and Codex skills. Capability-delta PR review catches behavior drift that hash pinning misses](https://github.com/skills-lock/skil-lock)|
 
 ## [▲](#keywords) Links
 |Type|Title|


### PR DESCRIPTION
Adds SkilLock to the Code section, alongside SkillFortify and ClawMoat.

SkilLock is an Apache 2.0 Go binary + GitHub Action that parses every SKILL.md in a repo, extracts the capability surface (shell commands, network URLs, file reads/writes), commits it as `skills.lock`, then runs a capability-delta diff on every PR. Catches the family of "SKILL.md legitimately changed and now does something different" cases that hash pinning misses.

Repo: https://github.com/skills-lock/skil-lock
Worked example: https://github.com/skills-lock/example-claude-code-skills