### PR TITLE
Add API Relay Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[CAI - Cybersecurity AI framework for autonomous security testing](https://github.com/aliasrobotics/CAI)|
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|
+|![][code]|[API Relay Audit - Local 14-step audit for AI API relays and LLM proxies. Checks prompt injection, model substitution, tool-call rewriting, error leakage, SSE anomalies, and Web3 wallet risks](https://github.com/toby-bridges/api-relay-audit)|
 |![][code]|[SkillFortify - Formal analysis and supply chain security for agentic AI skills. Sound static analysis, SAT-based dependency resolution, trust scoring, CycloneDX ASBOM. 5 theorems, F1=96.95%, 0% FP rate](https://github.com/varun369/skillfortify)|
 
 ## [▲](#keywords) Links


### PR DESCRIPTION
Adds API Relay Audit to the Code section. It is a local 14-step audit tool for AI API relays and LLM proxies, covering prompt injection, model substitution, tool-call rewriting, error leakage, SSE anomalies, and Web3 wallet-risk probes.