### PR TITLE
Add Redcells to AI security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[CAI - Cybersecurity AI framework for autonomous security testing](https://github.com/aliasrobotics/CAI)|
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|
+|![][code]|[Redcells - Automated adversarial testing platform for LLMs you own or control. OpenAI-compatible target models, iterative attack→refine layers, dashboard + API](https://redcells.net)|
 |![][code]|[SkillFortify - Formal analysis and supply chain security for agentic AI skills. Sound static analysis, SAT-based dependency resolution, trust scoring, CycloneDX ASBOM. 5 theorems, F1=96.95%, 0% FP rate](https://github.com/varun369/skillfortify)|
 
 ## [▲](#keywords) Links


### PR DESCRIPTION
Redcells is a public-beta platform for automated adversarial testing of LLMs you own or control.\n\n- OpenAI-compatible target models\n- Structured red-team jobs (prompt injection, jailbreak, data leakage, etc.)\n- Iterative attack→refine pipeline with per-layer prompts, responses, and judge scores\n- Web dashboard + HTTP API for CI/CD integration\n\nWebsite: https://redcells.net | Repo: https://github.com/awdemos/redcell